### PR TITLE
fix: module not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": {
     "name": "ralphhanna"
   },
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/**/*.js",


### PR DESCRIPTION
Sorry, but I forget that only mjs can use module. js can only use main.