### PR TITLE
refactor: use nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "README.md"
   ],
   "dependencies": {
+    "@lukeed/uuid": "^2.0.1",
     "bcrypt": "^5.0.1",
     "body-parser": "^1.19.0",
     "bpmn-moddle": "^8.1.0",
@@ -59,7 +60,6 @@
     "mongodb": "^3.6.0",
     "morgan": "^1.10.0",
     "multer": "*",
-    "nanoid": "^5.0.7",
     "nock": "^12.0.3",
     "nodemon": "^3.0.1",
     "typedoc-plugin-markdown": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "mongodb": "^3.6.0",
     "morgan": "^1.10.0",
     "multer": "*",
+    "nanoid": "^5.0.7",
     "nock": "^12.0.3",
     "nodemon": "^3.0.1",
     "typedoc-plugin-markdown": "^3.17.1",

--- a/src/engine/Execution.ts
+++ b/src/engine/Execution.ts
@@ -1,19 +1,13 @@
 
-import { Logger } from '../common/Logger';
-const fs = require('fs');
+import { nanoid } from 'nanoid';
 import { Item } from './Item';
 import { Token, TOKEN_TYPE  } from './Token';
 import { Loop} from './Loop';
-import { Element, Node, Flow , Definition, CallActivity, Process } from '../elements/'
-import { EXECUTION_EVENT, NODE_ACTION, FLOW_ACTION, TOKEN_STATUS, EXECUTION_STATUS, ITEM_STATUS, IDefinition } from '../';
-import { IInstanceData, IBPMNServer, IExecution, IAppDelegate , DefaultAppDelegate , DataHandler } from '../';
-import { EventEmitter } from 'events';
-import { BPMNServer, ServerComponent } from '../server';
+import { Definition, CallActivity, Process } from '../elements/'
+import { EXECUTION_EVENT, TOKEN_STATUS, EXECUTION_STATUS, IDefinition } from '../';
+import { IInstanceData, IExecution, DataHandler } from '../';
+import { ServerComponent } from '../server';
 import { InstanceObject } from './Model';
-
-
-const { v4: uuidv4 } = require('uuid');
-
 
 /**
  *  is accessed two ways:
@@ -625,9 +619,7 @@ public async restart(itemId, inputData:any,userName, options={}) :Promise<IExecu
     }
 
     getUUID() {
-
-        return uuidv4(); // -> '6c84fb90-12c4-11e1-840d-7b25c5ee775a' 
-
+        return nanoid() //=> "V1StGXR8_Z5jdHi6B-myT"
     }
 
 

--- a/src/engine/Execution.ts
+++ b/src/engine/Execution.ts
@@ -1,5 +1,4 @@
-
-import { nanoid } from 'nanoid';
+import { v4 as uuid } from '@lukeed/uuid';
 import { Item } from './Item';
 import { Token, TOKEN_TYPE  } from './Token';
 import { Loop} from './Loop';
@@ -619,7 +618,7 @@ public async restart(itemId, inputData:any,userName, options={}) :Promise<IExecu
     }
 
     getUUID() {
-        return nanoid() //=> "V1StGXR8_Z5jdHi6B-myT"
+        return uuid(); //=> '400fa120-5e9f-411e-94bd-2a23f6695704'
     }
 
 


### PR DESCRIPTION
This will prevent this happened

```
Error: crypto.getRandomValues() not supported. See https://github.com/uuidjs/uuid#getrandomvalues-not-supported
    at rng ($:/plugins/linonetwo/workflow-engine/startup/engine.js:16538:13)
    at v4 ($:/plugins/linonetwo/workflow-engine/startup/engine.js:16909:52)
    at _Execution.getUUID ($:/plugins/linonetwo/workflow-engine/startup/engine.js:17609:16)
    at new _Execution ($:/plugins/linonetwo/workflow-engine/startup/engine.js:17157:35)
    at Engine.<anonymous> ($:/plugins/linonetwo/workflow-engine/startup/engine.js:8456:29)
```

Also, nanoid is smaller and faster, and in our use case, it is as safe as uuid.

I also delete some unused imports.