### PR TITLE
fix: remove process.on('uncaughtException'

### DIFF
--- a/src/server/BPMNServer.ts
+++ b/src/server/BPMNServer.ts
@@ -10,17 +10,6 @@ import { EventEmitter } from 'events';
 
 console.log('BPMNServer from ',__filename);
 
-process.on('uncaughtException', function (err) {
-	console.log('***************BPMNServer UNCAUGHT ERROR***********');
-	try {
-		BPMNServer.getInstance().error = err;
-		BPMNServer.getInstance().logger.reportError(err);
-	}
-	catch (exc) {
-		console.log(err);
-    }
-	return;
-}); 
 
 
 const fs = require('fs');


### PR DESCRIPTION
This kind of code should added in user side's app code, not in a library code, otherwise it will ruin the debugging of app.

Because developer will use debugger that break on uncaught error.