### PR TITLE
fix: type of getServicesProvider

### DIFF
--- a/src/elements/Tasks.ts
+++ b/src/elements/Tasks.ts
@@ -63,11 +63,11 @@ class ServiceTask extends Node {
 
         item.log("invoking service:" + this.serviceName + " input:" + JSON.stringify(item.input));
 
-        const servicesProvider=await appDelegate.getServicesProvider(item.token.execution);
+        const servicesProvider= await appDelegate.getServicesProvider(item.token.execution);
 
         let obj = servicesProvider;
 
-      let method = this.serviceName;
+        let method = this.serviceName;
         if (obj && this.serviceName)  {
 
             const objs = this.serviceName.split('.');

--- a/src/engine/DefaultAppDelegate.ts
+++ b/src/engine/DefaultAppDelegate.ts
@@ -13,10 +13,8 @@ class DefaultAppDelegate implements IAppDelegate {
         });
     }
 
-    async getServicesProvider(context): Promise<this>
-    async getServicesProvider(context): Promise<IServiceProvider>
-    async getServicesProvider(context): Promise<this | IServiceProvider>  {
-        return this;
+    async getServicesProvider(context): Promise<IServiceProvider>  {
+        return this as unknown as IServiceProvider;
     }
 
     startUp(options) {

--- a/src/engine/DefaultAppDelegate.ts
+++ b/src/engine/DefaultAppDelegate.ts
@@ -1,8 +1,5 @@
-import { IExecution, Item, NODE_ACTION, FLOW_ACTION, IAppDelegate , IDefinition} from "../";
-
+import { IExecution, Item, IAppDelegate, IServiceProvider} from "../";
 import { moddleOptions} from '../elements/js-bpmn-moddle';
-
-
 
 class DefaultAppDelegate implements IAppDelegate {
     server;
@@ -15,13 +12,17 @@ class DefaultAppDelegate implements IAppDelegate {
             await self.executionEvent(context, event);
         });
     }
-    async getServicesProvider(context)  {
+
+    async getServicesProvider(context): Promise<this>
+    async getServicesProvider(context): Promise<IServiceProvider>
+    async getServicesProvider(context): Promise<this | IServiceProvider>  {
         return this;
     }
 
     startUp(options) {
         console.log('server started..');
     }
+
     sendEmail(to, msg, body) {
         throw Error("sendEmail must be implemented by AppDelegate");
     }
@@ -29,12 +30,15 @@ class DefaultAppDelegate implements IAppDelegate {
     get moddleOptions() {
         return moddleOptions;
     }
+
     async executionStarted(execution: IExecution) {
 
     }
+
     async executionEvent(context,event) {
 
     }
+
     /**
      *  is called when a event throws a message
      * 

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -73,7 +73,7 @@ interface ILogger {
  * Object to respond to all named services
  */
 interface IServiceProvider {
-    [serviceName: string]: CallableFunction;
+    [serviceName: string]: CallableFunction | IServiceProvider;
 }
 
 /**
@@ -90,7 +90,7 @@ interface IAppDelegate {
     /**
      * Get the service task handlers, default to `this`, so you can add handlers on this class directly.
      */
-    getServicesProvider(execution: IExecution): IAppDelegate | IServiceProvider | Promise<IAppDelegate> | Promise<IServiceProvider>;
+    getServicesProvider(execution: IExecution): IServiceProvider | Promise<IServiceProvider>;
     sendEmail(to, msg, body);
     executionStarted(execution: IExecution);
     startUp(options); // start of server

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -72,7 +72,7 @@ interface ILogger {
 /**
  * Object to respond to all named services
  */
-export interface IServiceProvider {
+interface IServiceProvider {
     [serviceName: string]: CallableFunction;
 }
 
@@ -113,4 +113,4 @@ interface IAppDelegate {
     serviceCalled(input: Record<string, unknown>, execution: IExecution, item: IItem): unknown;
 }
 
-export { ILogger, IAppDelegate, IConfiguration }
+export { ILogger, IAppDelegate, IConfiguration, IServiceProvider }

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -68,6 +68,14 @@ interface ILogger {
     reportError(err: any): void;
     save(filename: any): Promise<void>;
 }
+
+/**
+ * Object to respond to all named services
+ */
+export interface IServiceProvider {
+    [serviceName: string]: CallableFunction;
+}
+
 /**
  *  Application Delegate Object to respond to various events and services:
  *  
@@ -79,12 +87,15 @@ interface ILogger {
  * */
 interface IAppDelegate {
     moddleOptions;
-    getServicesProvider(IExecution): any;       // to respond to all named services
+    /**
+     * Get the service task handlers, default to `this`, so you can add handlers on this class directly.
+     */
+    getServicesProvider(execution: IExecution): IAppDelegate | IServiceProvider | Promise<IAppDelegate> | Promise<IServiceProvider>;
     sendEmail(to, msg, body);
-    executionStarted(execution);
+    executionStarted(execution: IExecution);
     startUp(options); // start of server
-    messageThrown(signalId, data, messageMatchingKey: any, item: IItem);
-    signalThrown(signalId, data, messageMatchingKey: any, item: IItem);
+    messageThrown(signalId: string, data, messageMatchingKey: any, item: IItem);
+    signalThrown(signalId: string, data, messageMatchingKey: any, item: IItem);
     /**
      * 
      * is called when an event throws a message that can not be answered by another process
@@ -92,16 +103,14 @@ interface IAppDelegate {
      * @param messageId
      * @param data
      */
-    issueMessage(messageId, data);
-    issueSignal(messageId, data);
+    issueMessage(messageId: string, data);
+    issueSignal(messageId: string, data);
     /**
      * is called only if the serviceTask has no implementation; otherwise the specified implementation will be called.
      * 
      * @param item
      */
-    serviceCalled(serviceName,data,item: IItem);
-
-
+    serviceCalled(input: Record<string, unknown>, execution: IExecution, item: IItem): unknown;
 }
 
-export { ILogger ,IAppDelegate , IConfiguration }
+export { ILogger, IAppDelegate, IConfiguration }


### PR DESCRIPTION
This only modify type

allows this usage:

```ts
export class TiddlywikiAppDelegate extends DefaultAppDelegate {
  async serviceCalled(input: Record<string, unknown>, execution: Execution, item: Item): Promise<void> {
    console.log(`TW Service "${(item.node as ServiceTask).serviceName}" called with input`, input, 'but method is not existed.');
  }

  async getServicesProvider() {
    return twServiceProvider;
  }
}

```


```ts
import { Execution, IServiceProvider } from 'bpmn-server';

export const twServiceProvider: IServiceProvider = {
  'log-console'(input: Record<string, unknown>, _execution: Execution) {
    console.log('log-console service called:', input);
  },
  a: {
    b: () => {
      console.log('b is called');
    },
  },
};
```

output

```
server started..
log-console service called: { str: 'The text' }
b is called
```

![图片](https://github.com/bpmnServer/bpmn-server/assets/3746270/3ea26442-7db8-4ea8-a3f7-8c6d002e5943)
