### PR TITLE
feat: allow run on browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "debug": "^4.3.1",
         "dotenv": "^8.2.0",
         "errorhandler": "^1.5.1",
+        "eventemitter3": "^5.0.1",
         "fs-extra": "^9.1.0",
         "iso8601-duration": "^1.2.0",
         "lodash": "^4.17.20",
@@ -1259,6 +1260,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "debug": "^4.3.1",
     "dotenv": "^8.2.0",
     "errorhandler": "^1.5.1",
+    "eventemitter3": "^5.0.1",
     "fs-extra": "^9.1.0",
     "iso8601-duration": "^1.2.0",
     "lodash": "^4.17.20",

--- a/src/API/AccessManager.ts
+++ b/src/API/AccessManager.ts
@@ -15,7 +15,7 @@ class SecureUser implements ISecureUser {
     constructor(params: IUserInfo) {
         Object.assign(this, params);
 
-        if (process.env.REQUIRE_AUTHENTICATION === 'false' || process.env.ENFORCE_SECURITY === 'false') {
+        if (typeof process !=='undefined' && (process.env.REQUIRE_AUTHENTICATION === 'false' || process.env.ENFORCE_SECURITY === 'false')) {
             console.log('****Security is disabled as requested in .env****');
             byPass = true;
         }

--- a/src/API/SecureUser.ts
+++ b/src/API/SecureUser.ts
@@ -40,7 +40,7 @@ class SecureUser implements ISecureUser {
     constructor(params: IUserInfo) {
         Object.assign(this, params);
 
-        if (process.env.REQUIRE_AUTHENTICATION === 'false' || process.env.ENFORCE_SECURITY === 'false') {
+        if (typeof process !=='undefined' && (process.env.REQUIRE_AUTHENTICATION === 'false' || process.env.ENFORCE_SECURITY === 'false')) {
             console.log('****Security is disabled as requested in .env****');
             byPass = true;
         }

--- a/src/common/Logger.ts
+++ b/src/common/Logger.ts
@@ -2,8 +2,6 @@
 
 import { ILogger } from "../";
 
-const FS = require('fs');
-
 class Logger implements ILogger {
 
     debugMsgs = [];
@@ -30,7 +28,8 @@ class Logger implements ILogger {
         }
 
         if (this.toFile !== '') {
-                FS.appendFileSync(this.toFile, message);        
+            const fs = require('fs');
+            fs.appendFileSync(this.toFile, message);        
         }
         this.debugMsgs.push({date:new Date(),message, type,level:this.level});
         return ({date:new Date(),message,type,level:this.level});
@@ -120,17 +119,18 @@ class Logger implements ILogger {
         throw new Error(err);
     }
     async save(filename) {
+        const fs = require('fs');
         console.log("writing to:" + filename + " " + this.debugMsgs.length);
-        let id = FS.openSync(filename, 'w', 666);
+        let id = fs.openSync(filename, 'w', 666);
         {
-            FS.writeSync(id,'Started at: '+new Date().toISOString() + "\n", null, 'utf8');
+            fs.writeSync(id,'Started at: '+new Date().toISOString() + "\n", null, 'utf8');
 
             let l = 0;
             for (l = 0; l < this.debugMsgs.length; l++) {
                 let msg = this.debugMsgs[l];
                 if (msg.type == 'error') {
                     let line = msg.type + ": at line " + (l+1) + " " + msg.message;
-                    FS.writeSync(id, line + "\n", null, 'utf8');
+                    fs.writeSync(id, line + "\n", null, 'utf8');
                 }
             }
             for (l = 0; l < this.debugMsgs.length; l++) {
@@ -142,10 +142,10 @@ class Logger implements ILogger {
                     line = msg.message;
 
                 let level=this.level>-1 ? ' '.repeat(this.level):'';
-                FS.writeSync(id,level+line + "\n", null, 'utf8');
+                fs.writeSync(id,level+line + "\n", null, 'utf8');
             }
 
-            FS.closeSync(id );
+            fs.closeSync(id );
             this.clear();
 
         }

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -9,11 +9,6 @@ import { InstanceLocker } from './';
 
 import { QueryTranslator } from './QueryTranslator';
 
-const fs = require('fs');
-
-const MongoDB = require('./MongoDB').MongoDB;
-
-
 export const Instance_collection = 'wf_instances';
 export const Locks_collection = 'wf_locks';
 export const Archive_collection = 'wf_archives';
@@ -36,6 +31,7 @@ class DataStore extends ServerComponent  implements IDataStore {
 		super(server);
 
 		this.dbConfiguration = this.configuration.database.MongoDB;
+		const MongoDB = require('./MongoDB').MongoDB;
 		this.db = new MongoDB(this.dbConfiguration, this.logger);
 		this.locker=new InstanceLocker(this);
 

--- a/src/datastore/InstanceLocker.ts
+++ b/src/datastore/InstanceLocker.ts
@@ -34,7 +34,7 @@ class InstanceLocker {
     }
     async try(id) {
 
-        const lock={"id":id,"server":process.env.SERVER_ID,"time": new Date()};
+        const lock={"id":id,"server": typeof process !=='undefined' ? process.env.SERVER_ID : null,"time": new Date()};
 
         try
         {

--- a/src/datastore/ModelsData.ts
+++ b/src/datastore/ModelsData.ts
@@ -1,12 +1,5 @@
-import { Definition, IModelsDatastore } from "../";
-import { ServerComponent , BPMNServer } from "../";
+import { Definition } from "../";
 import { IProcessData, IBpmnModelData, IEventData } from "../interfaces/";
-
-
-const fs = require('fs');
-const Path = require('path')
-const MongoDB = require('./MongoDB').MongoDB;
-
 
 class BpmnModelData implements IBpmnModelData {
     name;

--- a/src/datastore/ModelsDatastore.ts
+++ b/src/datastore/ModelsDatastore.ts
@@ -3,14 +3,7 @@ import { Definition } from "../elements";
 import { BPMNServer } from "../server";
 import {ModelsDatastoreDB} from "./ModelsDatastoreDB";
 
-
-const fs = require('fs');
-const Path = require('path')
-
-const BpmnModdle = require('bpmn-moddle');
-import { ServerComponent } from "../server/ServerComponent";
-import { IBpmnModelData, IModelsDatastore, IEventData } from "../interfaces/";
-import { BpmnModelData } from "./ModelsData";
+import { IModelsDatastore } from "../interfaces/";
 
 
 class ModelsDatastore extends ModelsDatastoreDB implements IModelsDatastore {
@@ -30,10 +23,11 @@ class ModelsDatastore extends ModelsDatastoreDB implements IModelsDatastore {
     async getList(query=null): Promise<string[]> {
 
         let files = [];
-
+        const fs = require('fs');
         fs.readdirSync(this.definitionsPath).forEach(file => {
-            if (Path.extname(file) == '.bpmn') {
-                let name = Path.basename(file);
+            const path = require('path')
+            if (path.extname(file) == '.bpmn') {
+                let name = path.basename(file);
                 name = name.substring(0, name.length - 5);;
                 files.push({name,saved:null});
             }
@@ -62,7 +56,7 @@ class ModelsDatastore extends ModelsDatastoreDB implements IModelsDatastore {
     }
 
     private getFile(name, type,owner=null) {
-
+        const fs = require('fs');
         let file = fs.readFileSync(this.getPath(name,type),
             { encoding: 'utf8', flag: 'r' });
         return file;
@@ -70,7 +64,7 @@ class ModelsDatastore extends ModelsDatastoreDB implements IModelsDatastore {
     }
     private saveFile(name, type , data,owner=null) {
         let fullpath = this.getPath(name, type);
-
+        const fs = require('fs');
         fs.writeFile(fullpath, data, function (err) {
             if (err) throw err;
         });
@@ -98,7 +92,7 @@ class ModelsDatastore extends ModelsDatastoreDB implements IModelsDatastore {
     }
 
     async deleteModel(name: any,owner=null): Promise<void> {
-
+        const fs = require('fs');
         await super.deleteModel(name);
         await fs.unlink(this.definitionsPath + name + '.bpmn',  function (err) {
             if (err) console.log('ERROR: ' + err);
@@ -108,7 +102,7 @@ class ModelsDatastore extends ModelsDatastoreDB implements IModelsDatastore {
         });
     }
     async renameModel(name: any, newName: any,owner=null): Promise<boolean> {
-
+        const fs = require('fs');
         await super.renameModel(name, newName);
         await fs.rename(this.definitionsPath + name + '.bpmn', this.definitionsPath + newName + '.bpmn', function (err) {
             if (err) console.log('ERROR: ' + err);
@@ -135,7 +129,7 @@ class ModelsDatastore extends ModelsDatastoreDB implements IModelsDatastore {
 
         filesList.forEach(f => {
             const path=this.definitionsPath + f['name'] + '.bpmn';
-
+            const fs = require('fs');
             var stats = fs.statSync(path);
             var mtime = stats.mtime;
             models.set(f['name'], mtime);

--- a/src/datastore/ModelsDatastoreDB.ts
+++ b/src/datastore/ModelsDatastoreDB.ts
@@ -2,20 +2,10 @@
 import { Definition } from "../elements";
 import { BPMNServer } from "../server";
 
-
-
-const fs = require('fs');
-const Path = require('path')
-
-const BpmnModdle = require('bpmn-moddle');
 import { ServerComponent } from "../server/ServerComponent";
 import { IBpmnModelData, IModelsDatastore, IEventData } from "../interfaces/";
 import { BpmnModelData } from "./ModelsData";
 import { QueryTranslator } from "./QueryTranslator";
-
-
-const MongoDB = require('./MongoDB').MongoDB;
-
 
 const Definition_collection = 'wf_models';
 const Events_collection = 'wf_events';
@@ -28,6 +18,7 @@ class ModelsDatastoreDB extends ServerComponent implements IModelsDatastore {
         super(server);
 
         this.dbConfiguration = this.configuration.database.MongoDB;
+        const MongoDB = require('./MongoDB').MongoDB;
         this.db = new MongoDB(this.dbConfiguration, this.logger);
 
     }
@@ -238,6 +229,7 @@ class ModelsDatastoreDB extends ServerComponent implements IModelsDatastore {
         return true;
     }
     async export(name, folderPath,owner=null) {
+        const fs = require('fs');
 
         let model = await this.loadModel(name,owner);
 

--- a/src/datastore/MongoDB.ts
+++ b/src/datastore/MongoDB.ts
@@ -1,20 +1,8 @@
-'use strict';
-
-const MongoClient = require('mongodb').MongoClient;
-const MongoDb = require('mongodb');
-//const mongoose= require('mongoose');
-const assert = require('assert');
-
-//mongoose.set('useNewUrlParser', true);
-//mongoose.set('useFindAndModify', false);
-//mongoose.set('useCreateIndex', true);
-//mongoose.set('useUnifiedTopology', true);
-
-/*Replace update() with updateOne(), updateMany(), or replaceOne()
+/*
+Replace update() with updateOne(), updateMany(), or replaceOne()
 Replace remove() with deleteOne() or deleteMany().
 Replace count() with countDocuments(), unless you want to count how many documents are in the whole collection(no filter).In the latter case, use estimatedDocumentCount().
 */
-
 class MongoDB {
     client;
     dbConfig;
@@ -221,7 +209,7 @@ class MongoDB {
         let self = this;
         return new Promise(function (resolve, reject) {
 
-
+            const MongoDb = require('mongodb');
             collection.deleteOne({ _id: new MongoDb.ObjectID(id) },
                  function (err, result) {
                 if (err) {
@@ -238,7 +226,9 @@ class MongoDB {
     }
 
     async connect() {
-    // Return new promise 
+        // Return new promise 
+        const MongoClient = require('mongodb').MongoClient;
+
         const client = new MongoClient(this.dbConfig.db_url , { useUnifiedTopology: true });
 
     return new Promise(function (resolve, reject) {

--- a/src/elements/Definition.ts
+++ b/src/elements/Definition.ts
@@ -5,15 +5,12 @@ const BpmnModdle = require('bpmn-moddle');
 
 //const moddleOptions = require('./js-bpmn-moddle.json');
 
-import { Logger } from '../common/Logger';
-import { Node, Flow , MessageFlow ,NodeLoader , Process, Behaviour_names } from '.'; 
+import { Flow , MessageFlow ,NodeLoader , Process, Behaviour_names } from '.'; 
 import { BPMN_TYPE } from './NodeLoader';
 import { IDefinition } from '../interfaces/elements';
 import { BPMNServer } from '../server/BPMNServer';
-import { NODE_SUBTYPE, EXECUTION_EVENT } from '../interfaces';
+import { EXECUTION_EVENT } from '../interfaces';
 import { Transaction, SubProcess , AdHocSubProcess } from '.';
-
-const fs = require('fs');
 
 //DEBUG(moddleOptions);
 function DEBUG(...args) {

--- a/src/elements/Process.ts
+++ b/src/elements/Process.ts
@@ -1,12 +1,9 @@
 import { Execution } from '../engine/Execution';
 import { Token, TOKEN_TYPE } from '../engine/Token';
-import { IBehaviour, Behaviour } from "./behaviours";
-import { NODE_ACTION, FLOW_ACTION, EXECUTION_EVENT, TOKEN_STATUS, ITEM_STATUS, ScriptHandler } from '../';
+import { ScriptHandler } from '../';
 
-import { Item } from '../engine/Item';
 import { Node, Definition } from '.';
 import { IExecution, NODE_SUBTYPE } from '../interfaces';
-import { exec } from 'child_process';
 
 
 class Process {

--- a/src/engine/Token.ts
+++ b/src/engine/Token.ts
@@ -1,15 +1,10 @@
 
-import { Logger } from '../common/Logger';
-const fs = require('fs');
-
 import { Execution } from './Execution';
-import { SubProcess ,  LoopBehaviour , Element, Node, Flow, Behaviour_names } from '../elements/'
-import { EXECUTION_EVENT , NODE_ACTION , FLOW_ACTION, TOKEN_STATUS, EXECUTION_STATUS,  ITEM_STATUS, INode, NODE_SUBTYPE} from '../';
-import { EventEmitter } from 'events';
+import { Node, Behaviour_names } from '../elements/'
+import { NODE_ACTION , TOKEN_STATUS, ITEM_STATUS, NODE_SUBTYPE} from '../';
 import { Loop } from './Loop';
 import { Item } from './Item';
-import { IToken, IExecution, IItem } from '../interfaces/engine';
-
+import { IToken, IExecution } from '../interfaces/engine';
 
 /*
  *  Tokens:

--- a/src/interfaces/datastore.ts
+++ b/src/interfaces/datastore.ts
@@ -1,7 +1,5 @@
-import { IExecution, ILogger,  IDefinition, IConfiguration, IInstanceData } from './';
+import { IDefinition, IInstanceData } from './';
 import { IBpmnModelData, IItemData, IEventData } from './';
-import { EventEmitter } from 'events';
-import { BPMNServer } from '../server';
 
 interface IDataStore {
     dbConfiguration: any;

--- a/src/interfaces/engine.ts
+++ b/src/interfaces/engine.ts
@@ -1,10 +1,7 @@
-import { ITEM_STATUS, EXECUTION_STATUS, NODE_ACTION, FLOW_ACTION, TOKEN_STATUS } from './Enums';
+import { NODE_ACTION, TOKEN_STATUS } from './Enums';
 import { IItemData , IInstanceData } from './';
-import { ILogger, IAppDelegate, IBPMNServer, IDefinition, IElement, Execution, Token, Item, Element, INode, Node, IServerComponent } from '../';
-import { EventEmitter } from 'events';
-interface IDataStore {
+import { ILogger, IAppDelegate, IBPMNServer, IDefinition, Token, Item, Element, Node, IServerComponent } from '../';
 
-}
 interface IToken {
     id: any;
     type;

--- a/src/interfaces/server.ts
+++ b/src/interfaces/server.ts
@@ -1,12 +1,11 @@
-import { IExecution , ILogger , IItem, IItemData , IDefinition, IConfiguration, IAppDelegate, IDataStore,IModelsDatastore } from '../';
-import { EventEmitter } from 'events';
-
-
+import { IExecution , ILogger , IItem, IConfiguration, IAppDelegate, IDataStore,IModelsDatastore } from '../';
+import type { EventEmitter } from 'eventemitter3';
+import type { EventEmitter as NodeEventEmitter } from 'events';
 
 interface IBPMNServer {
 
     engine: IEngine;
-    listener: EventEmitter;
+    listener: EventEmitter | NodeEventEmitter;
     configuration: IConfiguration;
     logger: ILogger;
     definitions: IModelsDatastore;

--- a/src/server/BPMNServer.ts
+++ b/src/server/BPMNServer.ts
@@ -7,7 +7,6 @@ import { Engine } from './Engine';
 import { Cron } from './Cron';
 import { EventEmitter } from 'events';
 
-console.log('BPMNServer from ',__filename);
 
 const fs = require('fs');
 /**

--- a/src/server/BPMNServer.ts
+++ b/src/server/BPMNServer.ts
@@ -1,14 +1,9 @@
-
 import { Logger } from '../common/Logger';
-
-
 import { IConfiguration, ILogger, IAppDelegate, IBPMNServer, IDataStore, ICacheManager } from '../';
 import { Engine } from './Engine';
 import { Cron } from './Cron';
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'eventemitter3';
 
-
-const fs = require('fs');
 /**
  *	The main class of Server Layer
  *	provides the full functionalities:
@@ -76,17 +71,18 @@ class BPMNServer implements IBPMNServer {
 		}
 	}
 	status() {
-		const { memoryUsage } = require('node:process');
-
-
-		return {version: BPMNServer.getVersion(),
+		return {
+			version: BPMNServer.getVersion(),
 			cache: this.cache.list,
-			engineRunning: this.engine.runningCounter, engineCalls: this.engine.callsCounter,
-			memoryUsage: memoryUsage()};
+			engineRunning: this.engine.runningCounter,
+			engineCalls: this.engine.callsCounter,
+			memoryUsage: typeof __dirname === 'undefined' ? require('node:process').memoryUsage() : null,
+		};
 	}
 	static getVersion() {
 		if (typeof __dirname === 'undefined') return 'unknown';
 		const configPath = __dirname+'/../../package.json';
+		const fs = require('fs');
 
 		if (fs.existsSync(configPath)) {
 

--- a/src/server/CacheManager.ts
+++ b/src/server/CacheManager.ts
@@ -1,12 +1,5 @@
-
-import { Logger } from '../common/Logger';
-
 import { ServerComponent} from './ServerComponent';
-import { Engine } from '.';
-
 import { EXECUTION_EVENT, ICacheManager, IExecution } from '../interfaces';
-
-const fs = require('fs');
 
 class NoCacheManager extends ServerComponent implements ICacheManager {
 


### PR DESCRIPTION
I inline the fs, path, process to the method that use them. Otherwise they will cause error even I already use a custom implementation.

'events' is nodejs only, so I install a tiny npm package.

I also fix all unused imports I meet, hope you don't mind.

After this, bpmn-server can run on browser, webworker, service worker, browser extensions. I think this make it possible to execute bpmn right inside bpmn-js based editor.

![图片](https://github.com/user-attachments/assets/03bf5c5b-5bae-4e37-b4d9-46365e13115c)

basically will fixes #206 , tested locally with pnpm link. Can you release a new version after this?