### PR TITLE
 Route engine/task diagnostics through Logger; stop dumping payloads to stdout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bpmn-server",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bpmn-server",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@lukeed/uuid": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bpmn-server",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "BPMN 2.0 Server including Modeling, Execution and Persistence, an open source for Node.js",
   "license": "MIT",
   "type": "module",
@@ -28,5 +28,7 @@
     "tsx": "^4.23.0",
     "typescript": "^6.0.3"
   },
-  "engines": { "node": ">=20.0.0" }
+  "engines": {
+    "node": ">=20.0.0"
+  }
 }

--- a/src/dmn/DMNEngine.ts
+++ b/src/dmn/DMNEngine.ts
@@ -10,7 +10,8 @@ class DMNEngine {
     }
     async load(filePath: string) {
         this.table= await DMNParser.loadDMNFile(filePath);
-        console.log(filePath,'loaded');
+        if (this.options.debug==true)
+            console.log(filePath,'loaded');
         return this;
     }
 

--- a/src/elements/Tasks.ts
+++ b/src/elements/Tasks.ts
@@ -131,16 +131,13 @@ class BusinessRuleTask extends ServiceTask {
             //throw new Error("Business Rule Task Not supported in this release.");
             
             businessRule = this.def.$attrs["camunda:decisionRef"];
-            console.log("invoking business rule:" + businessRule)
 
             const filePath=path+'/'+businessRule+'.dmn.xml';
-            console.log(' invoking ',filePath,' rules file')
-            const dmn=await new DMNEngine({debug:true}).load(filePath);
-            
+            token.log('..invoking business rule ' + businessRule + ' from ' + filePath);
+            const dmn=await new DMNEngine().load(filePath);
+
             item.output = await dmn.evaluate(item.input);
-            console.log("**** Business Rule input","item.input",item.input,"result:",item.output);
-            
-           
+            token.log('..business rule ' + businessRule + ' evaluated');
         }
         return NODE_ACTION.end;
     }

--- a/src/server/Engine.ts
+++ b/src/server/Engine.ts
@@ -458,7 +458,6 @@ class Engine extends ServerComponent implements IEngine{
 		}
 		else {
 			this.logger.log('** engine.throwMessage failed to find a target for ',JSON.stringify(itemsQuery));
-			console.log('** engine.throwMessage failed to find a target for ', JSON.stringify(itemsQuery));
 
         }
 		return null;
@@ -506,11 +505,11 @@ class Engine extends ServerComponent implements IEngine{
 		itemsQuery["items.status"] = 'wait';
 
 		const items = await this.dataStore.findItems(itemsQuery);
-		console.log('throw signal itemsQuery:', itemsQuery,items.length);
+		this.logger.log('^Action:engine.throwSignal ' + signalId + ' targets:' + items.length);
 		if (items.length > 0) {
 			for (var i = 0; i < items.length; i++) {
 				let item = items[i];
-				console.log(`Throw Signal ${signalId} found target: ${item.processName} ${item.id}`);
+				this.logger.log(`..throwSignal ${signalId} found target: ${item.processName} ${item.id}`);
 			}
 
 			for (var i = 0; i < items.length; i++) {
@@ -549,9 +548,7 @@ class Engine extends ServerComponent implements IEngine{
 		let insts=await ds.findInstances(query,{"projection":{"id":1}});
 
 		let source=await this.server.definitions.getSource(model);
-		console.log(source);
-
-		console.log(insts);
+		this.logger.log(`^Action:engine.upgrade ${model} instances:${insts.length}`);
 		const resIds=[];
 		let self=this;
 		for(let i=0;i<insts.length;i++) {


### PR DESCRIPTION
## Problem

A handful of `console.log` calls on normal-operation paths bypass the `Logger` the rest
of the codebase uses. They cannot be silenced by log level or configuration, and two of
them print entire payloads.

`Engine.upgrade()` prints the complete BPMN source of the model being upgraded,
followed by the full instance list:

```ts
let source = await this.server.definitions.getSource(model);
console.log(source);

console.log(insts);
```

`Engine.throwSignal()` prints a line per signal throw plus a line per matched target,
while the neighbouring `throwMessage()` already does the equivalent via `this.logger`.
`throwMessage()` itself logs the same failure message **twice** — once through the
logger and once through `console.log`:

```ts
this.logger.log('** engine.throwMessage failed to find a target for ', JSON.stringify(itemsQuery));
console.log('** engine.throwMessage failed to find a target for ', JSON.stringify(itemsQuery));
```

`BusinessRuleTask.run()` prints three lines per execution, one of which dumps
`item.input` and `item.output` — potentially sensitive application data — and it
constructs `new DMNEngine({debug:true})`, forcing DMN's own debug output on for every
business rule task regardless of how the host has configured things.

`DMNEngine.load()` prints unconditionally even though the class gates all its other
output behind `this.options.debug==true`.

## Change

Diagnostics move to the existing logging mechanisms; nothing is silently dropped.

**`src/server/Engine.ts`**

- `throwMessage()` — removed the duplicated `console.log`; the `this.logger.log` line
  immediately above already carries the identical message.
- `throwSignal()` — converted both statements to `this.logger.log`, matching
  `throwMessage()`'s existing `^Action:` / `..` prefix convention.
- `upgrade()` — replaced the source and instance-list dumps with a single logger line
  recording the model name and instance count. The full BPMN source is available via
  `definitions.getSource()` for anyone who needs it; printing it on every upgrade seems
  unlikely to be intended.

**`src/elements/Tasks.ts`** (`BusinessRuleTask`)

- Three `console.log` calls replaced with two `token.log` calls, consistent with
  `ScriptTask` and `SubProcess` in the same file. The dump of `item.input` /
  `item.output` is not reproduced — the values are already visible in the item record.
- `new DMNEngine({debug:true})` → `new DMNEngine()`, so the engine's default applies
  instead of forcing debug output on.

**`src/dmn/DMNEngine.ts`**

- `load()`'s `console.log(filePath,'loaded')` is now gated behind
  `this.options.debug==true`, matching how `evaluate()` and `matchesRule()` already
  guard their output in the same file.

## Scope

Deliberately narrow: only statements that fire during **normal operation** and bypass
the logger.

## Compatibility

No public API, signature or control-flow changes. `tsc --noEmit` reports no new errors
against the baseline.

The one visible difference for consumers: output that previously always appeared on
stdout now respects the `Logger`. Anyone relying on the DMN "loaded" line can restore
it with `new DMNEngine({debug:true})`.

## Testing

- `npx tsc --noEmit` — no new errors versus baseline.
- Ran the existing test suite; results unchanged.
- Exercised `engine.throwSignal`, `engine.upgrade` and a Business Rule task against a
  local server: behaviour identical, diagnostics now appear via the logger.